### PR TITLE
ISSUE-30: fix: Scale UI for mobiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,43 +25,45 @@
                 </div>
             </div>
 
-            <div id="grid_container">
-                <div class="tile" id="tile_0" onclick="select(0)"></div>
-                <div class="tile" id="tile_1" onclick="select(1)"></div>
-                <div class="tile" id="tile_2" onclick="select(2)"></div>
-                <div class="tile" id="tile_3" onclick="select(3)"></div>
-                <div class="tile" id="tile_4" onclick="select(4)"></div>
-                <div class="tile" id="tile_5" onclick="select(5)"></div>
-                <div class="tile" id="tile_6" onclick="select(6)"></div>
-                <div class="tile" id="tile_7" onclick="select(7)"></div>
-                <div class="tile" id="tile_8" onclick="select(8)"></div>
-                <div class="tile" id="tile_9" onclick="select(9)"></div>
-                <div class="tile" id="tile_10" onclick="select(10)"></div>
-                <div class="tile" id="tile_11" onclick="select(11)"></div>
-                <div class="tile" id="tile_12" onclick="select(12)"></div>
-                <div class="tile" id="tile_13" onclick="select(13)"></div>
-                <div class="tile" id="tile_14" onclick="select(14)"></div>
-                <div class="tile" id="tile_15" onclick="select(15)"></div>
-                <div class="tile" id="tile_16" onclick="select(16)"></div>
-                <div class="tile" id="tile_17" onclick="select(17)"></div>
-                <div class="tile" id="tile_18" onclick="select(18)"></div>
-                <div class="tile" id="tile_19" onclick="select(19)"></div>
-                <div class="tile" id="tile_20" onclick="select(20)"></div>
-                <div class="tile" id="tile_21" onclick="select(21)"></div>
-                <div class="tile" id="tile_22" onclick="select(22)"></div>
-                <div class="tile" id="tile_23" onclick="select(23)"></div>
-                <div class="tile" id="tile_24" onclick="select(24)"></div>
-                <div class="tile" id="tile_25" onclick="select(25)"></div>
-                <div class="tile" id="tile_26" onclick="select(26)"></div>
-                <div class="tile" id="tile_27" onclick="select(27)"></div>
-                <div class="tile" id="tile_28" onclick="select(28)"></div>
-                <div class="tile" id="tile_29" onclick="select(29)"></div>
-                <div class="tile" id="tile_30" onclick="select(30)"></div>
-                <div class="tile" id="tile_31" onclick="select(31)"></div>
-                <div class="tile" id="tile_32" onclick="select(32)"></div>
-                <div class="tile" id="tile_33" onclick="select(33)"></div>
-                <div class="tile" id="tile_34" onclick="select(34)"></div>
-                <div class="tile" id="tile_35" onclick="select(35)"></div>
+            <div id="scale_container">
+                <div id="grid_container">
+                    <div class="tile" id="tile_0" onclick="select(0)"></div>
+                    <div class="tile" id="tile_1" onclick="select(1)"></div>
+                    <div class="tile" id="tile_2" onclick="select(2)"></div>
+                    <div class="tile" id="tile_3" onclick="select(3)"></div>
+                    <div class="tile" id="tile_4" onclick="select(4)"></div>
+                    <div class="tile" id="tile_5" onclick="select(5)"></div>
+                    <div class="tile" id="tile_6" onclick="select(6)"></div>
+                    <div class="tile" id="tile_7" onclick="select(7)"></div>
+                    <div class="tile" id="tile_8" onclick="select(8)"></div>
+                    <div class="tile" id="tile_9" onclick="select(9)"></div>
+                    <div class="tile" id="tile_10" onclick="select(10)"></div>
+                    <div class="tile" id="tile_11" onclick="select(11)"></div>
+                    <div class="tile" id="tile_12" onclick="select(12)"></div>
+                    <div class="tile" id="tile_13" onclick="select(13)"></div>
+                    <div class="tile" id="tile_14" onclick="select(14)"></div>
+                    <div class="tile" id="tile_15" onclick="select(15)"></div>
+                    <div class="tile" id="tile_16" onclick="select(16)"></div>
+                    <div class="tile" id="tile_17" onclick="select(17)"></div>
+                    <div class="tile" id="tile_18" onclick="select(18)"></div>
+                    <div class="tile" id="tile_19" onclick="select(19)"></div>
+                    <div class="tile" id="tile_20" onclick="select(20)"></div>
+                    <div class="tile" id="tile_21" onclick="select(21)"></div>
+                    <div class="tile" id="tile_22" onclick="select(22)"></div>
+                    <div class="tile" id="tile_23" onclick="select(23)"></div>
+                    <div class="tile" id="tile_24" onclick="select(24)"></div>
+                    <div class="tile" id="tile_25" onclick="select(25)"></div>
+                    <div class="tile" id="tile_26" onclick="select(26)"></div>
+                    <div class="tile" id="tile_27" onclick="select(27)"></div>
+                    <div class="tile" id="tile_28" onclick="select(28)"></div>
+                    <div class="tile" id="tile_29" onclick="select(29)"></div>
+                    <div class="tile" id="tile_30" onclick="select(30)"></div>
+                    <div class="tile" id="tile_31" onclick="select(31)"></div>
+                    <div class="tile" id="tile_32" onclick="select(32)"></div>
+                    <div class="tile" id="tile_33" onclick="select(33)"></div>
+                    <div class="tile" id="tile_34" onclick="select(34)"></div>
+                    <div class="tile" id="tile_35" onclick="select(35)"></div>
+                </div>
             </div>
 
             <div class="btn btn-secondary" onclick="reset()" id="clear_button">clear</div>

--- a/style.css
+++ b/style.css
@@ -4,12 +4,20 @@ body{
 }
 
 #container{
-    width: 366px;
-    height: auto;
     position: absolute;
+    width: 400px;
+    margin-left: -200px;
     left: 50%;
-    margin-left: -180px;
+    height: auto;
 }
+
+@media only screen and (max-width: 600px) {
+    #container {
+        width: 90%;
+        margin-left: 5%;
+        left: 0;
+    }
+  }
 
 #title{
     width: 100%;
@@ -20,29 +28,41 @@ body{
     margin: 10px 0px 10px 0px;
 }
 
+#scale_container{
+    position: relative;
+	width: 100%;
+    padding-top: 100%;
+    margin-bottom: 20px;
+}
+
 #grid_container{
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
     background-color: rgb(230,230,230);
     color: rgb(50,50,50);
     font-weight: bold;
     font-size: 22px;
-    height: 360px;
-    width: 360px;
+    box-sizing:border-box;
     border: 3px solid rgb(230,230,230);
-    margin-bottom: 20px;
     border-radius: 8px;
 }
 
 .tile{
-    height: 54px;
-    width: 54px;
+    height: 16.666666%;
+    width: 16.666666%;
     background: rgb(250,250,250);
+    box-sizing:border-box;
     border: 3px solid rgb(230,230,230);
-    float: left;
-    line-height: 54px;
-    text-align: center;
     cursor: pointer;
     transition-duration: 0.15s;
     border-radius: 8px;
+    float: left;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .tile:active{
@@ -94,6 +114,8 @@ sub{
     color: rgba(20,20,20,0.5);
     font-size: 15px;
     font-weight: 500;
+    margin-top: 15px;
+    margin-left: 5px;
 }
 
 #score_row{


### PR DESCRIPTION
UI previously didn't scale below a certain size.

This ensures that the grid flexibly scales at small sizes by making the
tile height equal to the tile width, which is proportional to the screen
width. More [here](http://alistapart.com/article/creating-intrinsic-ratios-for-video/).

This kind of messed with the subscript due to the dynamic vertical
alignment of the tile content, but I've fixed that with some margin
tweaking.

This also creates a small margin at the bottom of the grid on safari
because 6 doesn't go into 100 perfectly, which is going to annoy me no
end, so I might change the grid to be 8x8.

Closes #30 