### PR TITLE
feat(gameloop): Add share button to gameover container

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
             <div id="stats_gameover_container">
                 <div class="modal_title">game over</div>
                 <div class="modal_subtitle">new griddle in <span id="stats_gameover_clock">00:00</span></div>
+                <div class="btn btn-primary" onclick="share_griddle()"><i class="fa-solid fa-clipboard"></i>&ensp;share</div>
             </div>
 
             <div class="modal_title">stats</div>

--- a/script.js
+++ b/script.js
@@ -418,6 +418,21 @@ function reset(){
     gh.reset()
 }
 
+function share_griddle(){
+    var share_text = `#griddle ${CURRENT_GRIDDLE_ID}: `
+    for(var i = 0; i < gh.words.count(); i++){
+        share_text += `(${gh.words.words[i][1]}) ${gh.words.words[i][0]} `
+    }
+    var temp_share_field = document.createElement("input")
+    temp_share_field.value = share_text
+    temp_share_field.select()
+    temp_share_field.setSelectionRange(0, 99999);  // mobile
+
+    navigator.clipboard.writeText(temp_share_field.value);
+
+    show_toast("copied griddle result to clipboard")
+}
+
 // INFO MODAL
 function show_info_modal(){
     document.getElementById("info_modal").style.display = "inline-block"

--- a/script.js
+++ b/script.js
@@ -419,11 +419,11 @@ function reset(){
 }
 
 function share_griddle(){
-    var share_text = `#griddle ${CURRENT_GRIDDLE_ID}: `
+    var share_text = `#griddle ${CURRENT_GRIDDLE_ID}:\n`
     for(var i = 0; i < gh.words.count(); i++){
-        share_text += `(${gh.words.words[i][1]}) ${gh.words.words[i][0]} `
+        share_text += `\n(${gh.words.words[i][1]}) ${gh.words.words[i][0]}`
     }
-    var temp_share_field = document.createElement("input")
+    var temp_share_field = document.createElement("textarea")
     temp_share_field.value = share_text
     temp_share_field.select()
     temp_share_field.setSelectionRange(0, 99999);  // mobile

--- a/style.css
+++ b/style.css
@@ -62,7 +62,6 @@ body{
 
 #stats_gameover_container{
     padding-bottom: 10px;
-    border-bottom: 1px solid rgb(230, 230, 230);
     display: none;
 }
 


### PR DESCRIPTION
This copies formatted results to the clipboard.

This doesn't work in Firefox, unless the user has enabled some
permissions.

Closes #15