### PR TITLE
fix(words): Increase bottom margin on container

### DIFF
--- a/style.css
+++ b/style.css
@@ -234,6 +234,7 @@ sub{
     width: 100%;
     border-top: 1px solid rgb(230, 230, 230);
     display: none;
+    margin-bottom: 10px;
 }
 
 .word{


### PR DESCRIPTION
The words container ends too close to the bottom of the screen.

It's also slightly inconsistent with the rest of the UI, which is 20px
vertically spaced.