### PR TITLE
ISSUE-56: feat(stats): track game streak

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,8 +1,12 @@
 // Game constants
 // Keeps track of whether wordle needs to be refreshed
-CURRENT_GRIDDLE_ID = new Date().toISOString().split("T")[0]
-GRIDDLE_OUTDATED = (CURRENT_GRIDDLE_ID != localStorage.last_griddle_id)
-localStorage.last_griddle_id = CURRENT_GRIDDLE_ID
+DATE_TODAY = new Date()
+DATE_YESTERDAY = new Date()
+DATE_YESTERDAY.setDate(DATE_TODAY.getDate() - 1)
+LAST_GRIDDLE_ID = DATE_YESTERDAY.toISOString().split("T")[0]
+CURRENT_GRIDDLE_ID = DATE_TODAY.toISOString().split("T")[0]
+GRIDDLE_OUTDATED = (CURRENT_GRIDDLE_ID != localStorage.last_played_griddle_id)
+localStorage.last_played_griddle_id = CURRENT_GRIDDLE_ID
 
 WORD_LIMIT = 5
 NUM_TILES = 36

--- a/index.html
+++ b/index.html
@@ -165,6 +165,10 @@
                     <span id="stats_modal__top_word">GRIDDLE</span>
                 </div>
             </div>
+            <div class="modal_subtitle">game streak</div>
+            <div class="label">
+                <span id="stats_modal__game_streak">0</span> games
+            </div>
             <div class="modal_subtitle">games played</div>
             <div class="label">
                 <span id="stats_modal__games_played">0</span> games

--- a/script.js
+++ b/script.js
@@ -501,6 +501,7 @@ function show_stats_modal(){
     document.getElementById("stats_modal__top_word_score").innerText = localStorage.top_word_score || "0"
     document.getElementById("stats_modal__top_game_score").innerText = localStorage.top_game_score || "0"
     document.getElementById("stats_modal__games_played").innerText = localStorage.games_played || "0"
+    document.getElementById("stats_modal__game_streak").innerText = localStorage.game_streak || "0"
 
     document.getElementById("stats_modal").style.display = "inline-block"
 }

--- a/script.js
+++ b/script.js
@@ -394,7 +394,24 @@ class GriddleHandler{
     // STATS
     _save_game_stats(){
         this.score.check_for_high_score()
+        this._check_game_streak()
         this._increment_games_played()
+    }
+
+    _check_game_streak(){
+        var last_completed_griddle = localStorage.last_completed_griddle_id
+        // Increment streak if last completed griddle was yesterday
+        if(last_completed_griddle == LAST_GRIDDLE_ID){
+            var streak = parseInt(localStorage.griddle_streak)
+            if(streak) localStorage.griddle_streak = streak + 1
+            else localStorage.griddle_streak = 1
+
+            // Display toast on every 10th griddle streak
+            if(streak % 10 == 0) show_toast("griddle streak: " + streak)
+        } else{
+            var streak = 1
+            localStorage.game_streak = streak
+        }
     }
 
     _increment_games_played(){


### PR DESCRIPTION
## feat(stats): Store griddle streak

This required some modification of how griddle ID's are computed and
store. We check if the last griddle ID matches the last griddle ID
_played_, and if it does, we increase the streak.

If there is no last griddle ID played, or if it doesn't match, the
streak drops back down to 1.

## feat(stats): Display game streak

Display the user's current game streak in the stats panel.

Closes #56 