### PR TITLE
fix(stats): Update and display griddle streak

### DIFF
--- a/script.js
+++ b/script.js
@@ -434,6 +434,7 @@ class GriddleHandler{
             var streak = 1
             localStorage.game_streak = streak
         }
+        localStorage.last_completed_griddle_id = CURRENT_GRIDDLE_ID
     }
 
     _increment_games_played(){
@@ -532,7 +533,7 @@ function show_stats_modal(){
     document.getElementById("stats_modal__top_word_score").innerText = localStorage.top_word_score || "0"
     document.getElementById("stats_modal__top_game_score").innerText = localStorage.top_game_score || "0"
     document.getElementById("stats_modal__games_played").innerText = localStorage.games_played || "0"
-    document.getElementById("stats_modal__game_streak").innerText = localStorage.game_streak || "0"
+    document.getElementById("stats_modal__game_streak").innerText = localStorage.griddle_streak || "0"
 
     document.getElementById("stats_modal").style.display = "inline-block"
 }


### PR DESCRIPTION
Corrected the reference to the griddle streak in local storage when
rendering the streak.

Saved the last griddle completed, used to calculate the streak. I
considered using the `last_griddle_played_id`, but you should only be
eligible for a streak if you complete the griddle.