### PR TITLE
fix(streak): Correct streak storage variable

### DIFF
--- a/script.js
+++ b/script.js
@@ -432,7 +432,7 @@ class GriddleHandler{
             if(streak % 10 == 0) show_toast("griddle streak: " + streak)
         } else{
             var streak = 1
-            localStorage.game_streak = streak
+            localStorage.griddle_streak = streak
         }
         localStorage.last_completed_griddle_id = CURRENT_GRIDDLE_ID
     }


### PR DESCRIPTION
This got muddled between `game_streak` and `griddle streak`.