### PR TITLE
fix(buffer): Reset cache when griddle outdated

### DIFF
--- a/script.js
+++ b/script.js
@@ -323,10 +323,14 @@ class GriddleHandler{
     }
 
     _load_buffer(){
-        // Load the buffer back from local storage if it exists and the
-        // griddle isn't outdated
+        // If there's a new griddle, ensure the local buffer cache is overwritten
+        // with the new buffer. This prevents yesterday's griddle being reused.
+        // Otherwise, reload any cached buffer. The buffer is cached when a user
+        // submits a word, therefore modifying the day's default buffer.
         try {
-            if(localStorage.buffer && !GRIDDLE_OUTDATED) {
+            if(GRIDDLE_OUTDATED) {
+                this._save_buffer()
+            } else if(localStorage.buffer) {
                 BUFFER = JSON.parse(localStorage.buffer)
             }
         } catch(err) {


### PR DESCRIPTION
*What I expected to happen*
* load the game
* griddle outdated
* use the new buffer from buffer.js
* the old buffer never gets used again

*What actually happens*
* load the game
* griddle outdated
* use the new buffer from buffer.js
* this doesn’t get written to local storage until the user submits a word
* the user immediately closes the browser before entering a word
* reopen the game
* GRIDDLE_OUTDATED is now False (last_played_griddle_id matches CURRENT_GRIDDLE after first reload)
* Old buffer is used.

*This fix*
This ensures the buffer is saved to local storage as soon as it is refreshed. If the player leaves the browser and reloads, yesterday’s griddle will no longer exist, ensuring players _always_ use the new griddle